### PR TITLE
fix(matriculaciones): muestra en rojo los días sin turnos

### DIFF
--- a/src/app/components/turnos/nuevo-turno.component.ts
+++ b/src/app/components/turnos/nuevo-turno.component.ts
@@ -107,7 +107,6 @@ export class NuevoTurnoComponent implements AfterViewInit {
     }
 
     private buildHorariosDisponibles() {
-        this.sinTurnos = false;
         this.horariosDisponibles = [];
         let res = null;
         let entradaU = false;
@@ -200,6 +199,7 @@ export class NuevoTurnoComponent implements AfterViewInit {
             dia: fecha.getDate()
         }).subscribe((datos) => {
             // Deshabilito los horarios ocupados.
+
             datos.forEach(item => {
                 const turnoOcupado = item._id;
                 this.horariosDisponibles.forEach(horario => {
@@ -208,9 +208,11 @@ export class NuevoTurnoComponent implements AfterViewInit {
                     }
                 });
             });
+
             const count = this.horariosDisponibles.filter((dia) => {
                 return dia.ocupado === true;
             });
+            this.sinTurnos = false;
             if (count.length === this.horariosDisponibles.length) {
                 this.sinTurnos = true;
             }
@@ -233,7 +235,6 @@ export class NuevoTurnoComponent implements AfterViewInit {
         this.$div.datepicker(this.options);
         this.$div.datepicker('setDate', startDate);
 
-        this.sinTurnos = false;
         this.onChangeFecha({ date: startDate })
     }
     private getPrimerDia(fecha?) {
@@ -254,10 +255,8 @@ export class NuevoTurnoComponent implements AfterViewInit {
                 while (date <= finMes && !hayTurnos) {
                     const indexDia = date.getDay().toString();
                     if (diasDeshabilitados.indexOf(date.getDay().toString()) < 0) {
-                        // console.log(countTurnosXDia)
                         const resultado = turnosMes.filter((dia) => {
                             return moment(date).isSame(moment(dia.fecha), 'day')
-                            // new Date(dia.fecha).getTime() === date.getTime()
                         })
                         if (resultado.length <= this.cupoDiario) {
                             hayTurnos = true;
@@ -290,10 +289,23 @@ export class NuevoTurnoComponent implements AfterViewInit {
         }
         let date = new Date(inicioMes)
         while (date <= finMes) {
+
             const resultado = countTurnosXDia.filter((dia) => {
                 return moment(date).isSame(moment(dia.fecha), 'day')
             })
+
+
+            if (resultado && resultado.length >= countTurnosXDia.length) {
+                fechasExcluidas.push(date);
+            }
+            const inicioAgenda = new Date(this.agendaConfig.horarioInicioTurnos).getHours();
+            const finAgenda = new Date(this.agendaConfig.horarioFinTurnos).getHours();
+            const disponibles = Math.round((Math.abs(inicioAgenda - finAgenda) * 60) / this.agendaConfig.duracionTurno);
+
             if (resultado.length > this.cupoDiario) {
+                fechasExcluidas.push(date);
+            }
+            if (resultado.length > disponibles) {
                 fechasExcluidas.push(date);
             }
             date = this.addDays(date, 1);

--- a/src/app/components/turnos/nuevo-turno.html
+++ b/src/app/components/turnos/nuevo-turno.html
@@ -37,15 +37,17 @@
             <label>Hora</label>
 
             <div class="row">
-                <span *ngIf='horariosDisponibles.length === 0' class="alert alert-danger">No hay mas turnos para la
-                    fecha seleccionada</span>
-                <span *ngIf='sinTurnos && horariosDisponibles.length > 0' class="alert alert-danger">No hay mas turnos para la
+                <!-- <span *ngIf='horariosDisponibles.length === 0' class="alert alert-danger">No hay mas turnos para la
+                    fecha seleccionada</span> -->
+                <span *ngIf='(sinTurnos && horariosDisponibles.length > 0) || horariosDisponibles.length === 0'
+                      class="alert alert-danger">No hay mas turnos para la
                     fecha seleccionada</span>
                 <ng-container *ngIf='!sinTurnos'>
                     <div *ngFor="let turno of horariosDisponibles; let idx = index">
                         <div class="col-md-6" style=" margin-bottom: 6px;">
-                            <button [disabled]="horariosDisponibles[idx] && horariosDisponibles[idx].ocupado" class="btn btn-primary"
-                                (click)="buildFechaTurno(horariosDisponibles[idx]) " [ngClass]="{'active':isActive(horariosDisponibles[idx]) == true}">
+                            <button [disabled]="horariosDisponibles[idx] && horariosDisponibles[idx].ocupado"
+                                    class="btn btn-primary" (click)="buildFechaTurno(horariosDisponibles[idx]) "
+                                    [ngClass]="{'active':isActive(horariosDisponibles[idx]) == true}">
                                 {{ horariosDisponibles[idx].hora }}:{{ (horariosDisponibles[idx].minutos == 0) ? '00' :
                                 horariosDisponibles[idx].minutos }} hs
                             </button>
@@ -59,12 +61,13 @@
 </div>
 <br>
 <div class="col-sm-12 text-center" *ngIf="sobreTurno">
-    <button class="btn btn-success pull-right" style="margin-right: 8px; margin-top: 8px" (click)="confirmSobreTurno()">Confirmar</button>
+    <button class="btn btn-success pull-right" style="margin-right: 8px; margin-top: 8px"
+            (click)="confirmSobreTurno()">Confirmar</button>
 </div>
 <div class="row" *ngIf="!turnoElegido " style="margin-bottom: 15px">
     <div class="col-sm-12 text-center" *ngIf="!sobreTurno">
-        <button [disabled]="horarioSi == false" class="btn btn-success pull-right" style="margin-right: 8px; margin-top: 8px"
-            (click)="confirmTurno()">Confirmar Turno</button>
+        <button [disabled]="horarioSi == false" class="btn btn-success pull-right"
+                style="margin-right: 8px; margin-top: 8px" (click)="confirmTurno()">Confirmar Turno</button>
     </div>
 
 </div>


### PR DESCRIPTION
### Requerimiento
* Muestra en rojo los días sin turnos en el calendario
### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
