### PR TITLE
MAT - Corregir parámetro en endpoint de turnos solicitado

### DIFF
--- a/src/app/components/profesionales/detalle-profesional.component.ts
+++ b/src/app/components/profesionales/detalle-profesional.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Output, Input, EventEmitter, HostBinding, ViewChild } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 import { Plex } from '@andes/plex';
 import { FotoGeneralComponent } from './foto-general.component';
@@ -27,7 +27,6 @@ export class DetalleProfesionalComponent implements OnInit {
     public mostrar = false;
     public mostrarGrado = false;
     public img64 = null;
-    public vieneDeDetalle = null;
     public confirmar = true;
     public tieneFirma = null;
     public tieneFirmaAdmin = null;
@@ -134,8 +133,6 @@ export class DetalleProfesionalComponent implements OnInit {
         idRenovacion: null,
         documentoViejo: null
     };
-    @Output() onShowListado = new EventEmitter();
-    @Output() showFormacion = new EventEmitter();
     @Output() showFoto = new EventEmitter();
     public tieneOtraEntidad;
 
@@ -144,16 +141,11 @@ export class DetalleProfesionalComponent implements OnInit {
         private _turnoService: TurnoService,
         private _numeracionMatriculasService: NumeracionMatriculasService,
         private route: ActivatedRoute,
-        private router: Router,
         public auth: Auth,
         private plex: Plex,
         private location: Location) { }
 
     ngOnInit() {
-        this.vieneDeDetalle = true;
-        // Este metodo se encarga de buscar, a partir del id del profesional obtenido por parametros de ruteo, un profesional
-        // en la coleccion de profesional. Si dicha coleccion no existe entonces procede a buscarla en la de turnosSolicitado
-        // y de esta forma poder mostrar sus datos en el HTML.
         this.route.params.pipe(
             switchMap(params => {
                 if (params && params['id']) {
@@ -176,14 +168,6 @@ export class DetalleProfesionalComponent implements OnInit {
                     );
                 } else {
                     this.profesional = profesional[0];
-                    if (!this.profesional.profesionalMatriculado) {
-                        return this._turnoService.getTurnoSolicitados(this.profesional.documento).pipe(
-                            tap((prof) => {
-                                this.flag = false;
-                                this.profesional = prof;
-                            })
-                        );
-                    }
                     this.flag = true;
                     this.habilitaPosgrado();
                     return of(null);

--- a/src/app/components/profesionales/detalle-profesional.component.ts
+++ b/src/app/components/profesionales/detalle-profesional.component.ts
@@ -157,6 +157,7 @@ export class DetalleProfesionalComponent implements OnInit {
             }),
             switchMap(({ params, profesional }) => {
                 if (!profesional.length) {
+                    // profesional no existente, cargar datos temporales de turno
                     return this._turnoService.getTurnoSolicitados(params['id']).pipe(
                         catchError(() => of(null)),
                         tap((profesionalTemporal: any) => {
@@ -168,6 +169,17 @@ export class DetalleProfesionalComponent implements OnInit {
                     );
                 } else {
                     this.profesional = profesional[0];
+                    if (!this.profesional.profesionalMatriculado) {
+                        // profesional existente, pero no matriculado
+                        return this._turnoService.getTurnoSolicitados(params['id']).pipe(
+                            tap((prof) => {
+                                this.flag = false;
+                                delete prof.createdAt;
+                                delete prof.createdBy;
+                                this.profesional = prof;
+                            })
+                        );
+                    }
                     this.flag = true;
                     this.habilitaPosgrado();
                     return of(null);

--- a/src/app/components/profesionales/profesional.html
+++ b/src/app/components/profesionales/profesional.html
@@ -122,7 +122,7 @@
                                 </plex-wrapper>
                             </ng-container>
                         </div>
-                        <div>
+                        <div *ngIf='profesional.domicilios[0]'>
                             <plex-title titulo="Domicilio {{profesional.domicilios[0].tipo}}" size="sm">
                                 <plex-button type="success" label="completar domicilios" type="primary btn-sm"
                                              (click)="completar()" class="pull-right">
@@ -153,7 +153,7 @@
                     </plex-grid>
 
                     <plex-grid type="full" responsive cols="2" colsSm="1">
-                        <div>
+                        <div *ngIf='profesional.domicilios[1]'>
                             <plex-title titulo="Domicilio {{profesional.domicilios[1].tipo}}" size="sm">
                             </plex-title>
                             <plex-grid type="full" cols="2">
@@ -178,7 +178,7 @@
                                 </plex-int>
                             </plex-grid>
                         </div>
-                        <div *ngIf='!noPoseedomicilioProfesional'>
+                        <div *ngIf='profesional.domicilios[2]'>
                             <plex-title titulo="Domicilio {{profesional.domicilios[2].tipo}}" size="sm">
                             </plex-title>
                             <plex-grid type="full" cols="2">
@@ -207,7 +207,7 @@
                 </plex-tab>
 
                 <!--DATOS DE PROFESIÓN-->
-                <plex-tab *ngIf='!editable' label="Datos de profesion">
+                <plex-tab *ngIf='!editable && profesional.formacionGrado.length' label="Datos de profesion">
                     <plex-grid type="full" responsive cols="3" colsSm="1" colsMd="2">
                         <plex-select label="Profesión" [(ngModel)]="profesional.formacionGrado[0].profesion"
                                      name='formacionPosgrado' (getData)="loadProfesiones($event)" [required]="true">

--- a/src/app/services/turno.service.ts
+++ b/src/app/services/turno.service.ts
@@ -37,8 +37,8 @@ export class TurnoService extends BaseService {
     saveTurnoSolicitados(turnoSolicitado: any) {
         return this._server.post(this.turnosSolicitados, turnoSolicitado);
     }
-    getTurnoSolicitados(dni: any): Observable<any> {
-        return this._server.get(this.turnosSolicitados + 'traePDni/' + dni);
+    getTurnoSolicitados(id: any): Observable<any> {
+        return this._server.get(this.turnosSolicitados + id);
     }
 
     getTurnos(url: string, searchParams: any): Observable<any> {
@@ -91,7 +91,7 @@ export class TurnoService extends BaseService {
             parametros.documento = searchParams.documento;
         }
 
-        if(searchParams.delDia){
+        if (searchParams.delDia) {
             parametros.delDia = searchParams.delDia;
         }
 


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/MAT-194

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se quita la ruta de turnos solicitados de profesionales por medio de documento, dejando solamente la que se accede por medio de id. Solo se solicitara en caso de que los mismos no se encuentre cargado en la colección "profesionales". 
2. Vinculado a corrección de error https://proyectos.andes.gob.ar/browse/MAT-204

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [X] Si https://github.com/andes/api/pull/2169
- [ ] No

NOTA: No se logró reproducir el error de forma directa pero si por medio de la BD. Para reproducir el mismo nos dirigimos al detalle del profesional donde se ven todos sus datos personales y, desde la base de datos, cambiamos dentro del profesional el atributo profesionalMatriculado a false. Luego hacemos un refresh a la pantalla y se observara un error de casteo. 
